### PR TITLE
fixed issues with directive update and multiple usages

### DIFF
--- a/src/i18n-directive.ts
+++ b/src/i18n-directive.ts
@@ -1,5 +1,4 @@
-///<reference path="../typings/index.d.ts"/>
-import {Directive, Input, Renderer, ElementRef, AfterContentInit} from '@angular/core';
+import {Directive, Input, Renderer, ElementRef, OnChanges} from '@angular/core';
 
 import {I18nService} from './i18n-service';
 
@@ -8,20 +7,18 @@ import {I18nService} from './i18n-service';
   providers: [],
   host: {}
 })
-export class I18nDirective implements AfterContentInit {
+export class I18nDirective implements OnChanges {
   @Input('i18n') content: string;
   @Input('i18n-placeholder') phContent: string;
 
   constructor(private i18n: I18nService, private el: ElementRef, private renderer: Renderer) {
   }
 
-  /* 
-     If the i18next module is initialized, the promise is resolved with the text to display.
+  ngOnChanges() {
+    this.updateDirectiveContent();
+  }
 
-     If the i18next module is not yet initialized, the promise is rejected: we subscribe
-     to the i18nextService observable which will alert us when the module is initialized 
-  */
-  ngAfterContentInit() {
+  private updateDirectiveContent() {
     this.loadAndRender(this.content, (s) => {
       this.renderer.setText(this.el.nativeElement, s);
     });
@@ -31,37 +28,27 @@ export class I18nDirective implements AfterContentInit {
     });
   }
 
-  loadAndRender(content: string, doRenderCallback) {
+  private loadAndRender(content: string, doRenderCallback) {
     if (!content) {
       return;
     }
-    console.log('content: ' + content);
 
     let code: string;
     let options: {} = {};
     try {
       let json = JSON.parse(content);
-      console.log('json: ' + JSON.stringify(json));
       code = Object.keys(json)[0];
       options = json[code];
     } catch (e) {
-      console.log('parsing error: ' + e);
       code = content;
     }
-    console.log('code: ' + code);
-    console.log('options: ' + JSON.stringify(options));
+
     this.i18n.tPromise(code, options)
-
-      .then((val: string) => {
-        doRenderCallback(val);
-      })
-
-      .catch((val: string) => {
-        doRenderCallback(' ');
-        var obs = this.i18n.whenReady$.subscribe(b => {
-          doRenderCallback(this.i18n.t(code, options));
-          setTimeout(() => { obs.unsubscribe() }, 0);
+        .then((val: string) => {
+          doRenderCallback(val);
+        })
+        .catch((err: Error) => {
+          console.log('Rendering of value failed. Error: ', err);
         });
-      });
   }
 }


### PR DESCRIPTION
Fixed two issues found during testing of solution to [passing options to directive](https://github.com/actimeo/ng2-i18next/issues/4#issuecomment-219944436).
- directive was not re-rendered when passed options were updated (counter, for example). Fixed by changing `onInit` hook to `onChanges` hook.
- only one of subscribed observers was notified that init has finished (due to usage of `share` operator). Changed `Observable` to `Promise` so that there is guarantee that config code is executed once and that translation is always done after config is done.

Also removed console.logs (passing options works).
Getting some errors while executing npm install, but they don't seem to be connected.
